### PR TITLE
Avoid an extra-escaping of dictionary name.

### DIFF
--- a/sdcv.el
+++ b/sdcv.el
@@ -422,7 +422,7 @@ Specify dictionaries to search in DICTIONARY-LIST."
   (setq sdcv-current-translate-object word)
   (let ((args `("-n" ,(substring-no-properties word))))
     (dolist (dict dictionary-list)
-      (push (concat "\"" dict "\"") args)
+      (push dict args)
       (push "-u" args))
     args))
 


### PR DESCRIPTION
Hello guys!

There is a problem if the dictionary name has spaces, which appeared since merge #2. The problem is that line https://github.com/stardiviner/sdcv.el/blob/master/sdcv.el#L425 was adopted from the previous code without careful checking. Avoiding extra-quotes should solve that (it works for me).

Best regards, Vladimir.