### PR TITLE
Add check for pronouncing word

### DIFF
--- a/sdcv.el
+++ b/sdcv.el
@@ -485,12 +485,12 @@ Otherwise return word around point."
 ;;; I add this function to pronounce
 (defun sdcv-pronounce-word (&optional word)
   "Pronounce `WORD' after querying."
-  (call-process-shell-command
-   sdcv-word-pronounce-command
-   nil nil nil
-   sdcv-word-pronounce-command-args
-   (shell-quote-argument word)
-   ))
+  (when sdcv-word-pronounce
+    (call-process-shell-command
+     sdcv-word-pronounce-command
+     nil nil nil
+     sdcv-word-pronounce-command-args
+     (shell-quote-argument word))))
 
 (provide 'sdcv)
 


### PR DESCRIPTION
Howdy,

I made some edits so that both sdcv-search-detail respects the setting in sdcv-word-pronounce by adding a check for sdcv-word-pronounce to sdcv-pronounce-word.